### PR TITLE
Add job status API endpoint

### DIFF
--- a/backend/controller/jobController.js
+++ b/backend/controller/jobController.js
@@ -1,0 +1,30 @@
+import axios from "axios";
+
+const CONTROL_M_API = "https://pisces.ortom8.com:8443/automation-api/run/jobs/status";
+
+export const getJobs = async (req, res) => {
+  try {
+    const { limit = 100, orderDateFrom, orderDateTo } = req.query;
+
+    const params = {
+      limit,
+      ...(orderDateFrom && { orderDateFrom }),
+      ...(orderDateTo && { orderDateTo })
+    };
+
+    const response = await axios.get(CONTROL_M_API, {
+      headers: {
+        "x-api-key": "b25QcmVtOjdhZGRiNzFhLTJiM2MtNDA1NS1iNzBhLTA0NzdlNjg3YTdjNw==",
+        "accept": "application/json"
+      },
+      params
+    });
+
+    console.log("[TempJobController] Response Status:", response.status);
+    res.json(response.data);
+
+  } catch (error) {
+    console.error("[TempJobController] Error:", error.message);
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/backend/routes/jobRoute.js
+++ b/backend/routes/jobRoute.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { getJobs } from "../controller/jobController";
+
+const router = express.Router();
+
+// GET /api/temp/jobs
+router.get("/jobs", getJobs);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,6 +33,9 @@ db.once('open', () => {
 const authRoutes = require('./routes/authRoutes');
 app.use('/api/auth', authRoutes);
 
+const jobRoutes = require('./routes/jobRoute');
+app.use('/api/temp', jobRoutes);
+
 // Start server
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);


### PR DESCRIPTION
Introduced a new controller and route to fetch job statuses from an external API. Integrated the route under /api/temp in the server for job-related queries.