### PR TITLE
Update CORS origins to include production URL

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -10,7 +10,7 @@ const PORT = process.env.PORT || 5000;
 // Middleware
 app.use(bodyParser.json());
 app.use(cors({
-  origin: 'http://localhost:3000',
+  origin: ['https://astronx.netlify.app', 'http://localhost:3000'],
   credentials: true,
 }));
 


### PR DESCRIPTION
Added 'https://astronx.netlify.app' to the allowed CORS origins alongside 'http://localhost:3000' to support requests from the deployed frontend.